### PR TITLE
LocalStorage for Authentication, dismiss success popups on request, headings, SettingsScreen

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Alert, Button, Form, ListGroup, Spinner, Stack } from "react-bootstrap";
 import { APIError, makeApiErrorFromAxiosError } from "../types/api/APIErrorResponse";
 import APISubstitution from "../types/api/APISubstitution";
@@ -12,11 +12,16 @@ const App = () => {
   const [renderedSubstitutions, renderSubstitutions] = useState([]);
 
   const [date, setDate] = useState(DateFormatter.apiDateString(new Date()));
-  const [auth, setAuth] = useState("TESTTOKEN");
+  const [auth, setAuth] = useState(window.localStorage.getItem("auth.token") ?? "");
 
   const [apiError, setApiError] = useState({} as APIError);
   const [apiErrored, setApiErrored] = useState(false);
   const [apiSuccess, setApiSuccess] = useState(false);
+
+  // Save auth token whenever it is changed
+  useEffect(() => {
+    window.localStorage.setItem("auth.token", auth);
+  }, [auth]);
 
   const makeRequest = () => {
     if (loading) {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -31,6 +31,7 @@ const App = () => {
     }
 
     setApiErrored(false);
+    setApiSuccess(false);
     setLoading(true);
     axios
       .get("https://api.chuangsheep.com/vplan", {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -5,23 +5,23 @@ import { APIError, makeApiErrorFromAxiosError } from "../types/api/APIErrorRespo
 import APISubstitution from "../types/api/APISubstitution";
 import { makeSubstitutionFromAPI } from "../types/Substitution";
 import DateFormatter from "../util/DateFormatter";
+import handleInputChange from "../util/handleInputChange";
+import SettingsScreen from "./SettingsScreen";
 import SubstitutionTable from "./SubstitutionTable";
+
+const CURRENT_LOCALSTORAGE_SCHEMA_VERSION = "1.0";
 
 const App = () => {
   const [loading, setLoading] = useState(false);
   const [renderedSubstitutions, renderSubstitutions] = useState([]);
 
   const [date, setDate] = useState(DateFormatter.apiDateString(new Date()));
-  const [auth, setAuth] = useState(window.localStorage.getItem("auth.token") ?? "");
 
   const [apiError, setApiError] = useState({} as APIError);
   const [apiErrored, setApiErrored] = useState(false);
   const [apiSuccess, setApiSuccess] = useState(false);
 
-  // Save auth token whenever it is changed
-  useEffect(() => {
-    window.localStorage.setItem("auth.token", auth);
-  }, [auth]);
+  const [showingSettings, showSettings] = useState(false);
 
   const makeRequest = () => {
     if (loading) {
@@ -34,7 +34,7 @@ const App = () => {
       .get("https://api.chuangsheep.com/vplan", {
         params: { date: date },
         headers: {
-          Authorization: `Bearer ${auth}`
+          Authorization: `Bearer ${window.localStorage.getItem("auth.token")}`
         }
       })
       .then((res) => {
@@ -53,13 +53,45 @@ const App = () => {
       });
   };
 
-  const handleDateInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setDate(event.currentTarget.value);
+  const initializeStorage = () => {
+    window.localStorage.clear();
+    window.localStorage.setItem("storage.ls.version", "1.0");
   };
 
-  const handleAuthInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setAuth(event.currentTarget.value);
-  };
+  // Validating localStorage when the App component is mounted
+  useEffect(() => {
+    const storageVersion = window.localStorage.getItem("storage.ls.version");
+    if (!storageVersion) {
+      // No storage exists so far
+      initializeStorage();
+    } else if (storageVersion === CURRENT_LOCALSTORAGE_SCHEMA_VERSION) {
+      // The storage is on the latest schema version - we're done here
+      return;
+      /*
+    } else if (storageVersion === "0.0") {
+      alert("Your localStorage was migrated to a new schema version!");
+    */
+    } else {
+      alert(
+        "Your localStorage is outdated and its version is no longer supported for migration. " +
+          "Your localStorage will be re-initialized. You will have to re-configure the app. " +
+          "Sorry for the inconvenience :c"
+      );
+      initializeStorage();
+    }
+  }, []);
+
+  if (showingSettings) {
+    return (
+      <SettingsScreen
+        dismiss={() => {
+          showSettings(false);
+        }}
+        resetStorage={initializeStorage}
+        currentStorageSchemeVersion={CURRENT_LOCALSTORAGE_SCHEMA_VERSION}
+      />
+    );
+  }
 
   return (
     <>
@@ -69,49 +101,53 @@ const App = () => {
             <Stack direction="horizontal" gap={5}>
               <Form.Group>
                 <Form.Label>Date</Form.Label>
-                <Form.Control type="text" placeholder="21.03.22" onChange={handleDateInputChange} value={date} />
+                <Form.Control type="text" placeholder="21.03.22" onChange={handleInputChange(setDate)} value={date} />
                 <Form.Text>The date to request the VPlan for</Form.Text>
-              </Form.Group>
-              <Form.Group>
-                <Form.Label>Auth</Form.Label>
-                <Form.Control
-                  plaintext={false}
-                  placeholder="TmV2ZXIgZ29ubmEgZ2l2ZSB5b3UgdXA="
-                  onChange={handleAuthInputChange}
-                  value={auth}
-                />
-                <Form.Text>You can get an AuthToken for the API from ChuangSheep!</Form.Text>
               </Form.Group>
 
               <div className="vr ms-auto" />
               <Spinner animation="border" size="sm" hidden={!loading} />
               <Button onClick={makeRequest}>Request</Button>
+              <Button
+                onClick={() => {
+                  showSettings(true);
+                }}
+                variant="secondary"
+              >
+                Settings
+              </Button>
             </Stack>
           </Form>
 
           {apiErrored && (
-            <Alert
-              variant="danger"
-              onClose={() => {
-                setApiErrored(false);
-              }}
-              dismissible
-            >
-              <strong>{apiError.message}</strong>
+            <>
               <br />
-              {apiError.description}
-            </Alert>
+              <Alert
+                variant="danger"
+                onClose={() => {
+                  setApiErrored(false);
+                }}
+                dismissible
+              >
+                <strong>{apiError.message}</strong>
+                <br />
+                {apiError.description}
+              </Alert>
+            </>
           )}
           {apiSuccess && (
-            <Alert
-              variant="success"
-              onClose={() => {
-                setApiSuccess(false);
-              }}
-              dismissible
-            >
-              Successfully fetched {renderedSubstitutions.length} entries.
-            </Alert>
+            <>
+              <br />
+              <Alert
+                variant="success"
+                onClose={() => {
+                  setApiSuccess(false);
+                }}
+                dismissible
+              >
+                Successfully fetched {renderedSubstitutions.length} entries.
+              </Alert>
+            </>
           )}
         </ListGroup.Item>
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -9,6 +9,8 @@ import handleInputChange from "../util/handleInputChange";
 import SettingsScreen from "./SettingsScreen";
 import SubstitutionTable from "./SubstitutionTable";
 
+import "../styles/home.css";
+
 const CURRENT_LOCALSTORAGE_SCHEMA_VERSION = "1.0";
 
 const App = () => {
@@ -95,6 +97,8 @@ const App = () => {
 
   return (
     <>
+      <h1 id="homeHeading">VPlan</h1>
+
       <ListGroup>
         <ListGroup.Item>
           <Form>

--- a/src/components/SettingsScreen.tsx
+++ b/src/components/SettingsScreen.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useState } from "react";
+import { Form, ListGroup, Button, Stack, ButtonGroup } from "react-bootstrap";
+
+import "../styles/settings.css";
+import handleInputChange from "../util/handleInputChange";
+
+interface ISettingsScreenProps {
+  dismiss: () => void;
+  resetStorage: () => void;
+  currentStorageSchemeVersion: string;
+}
+
+const SettingsScreen = (props: ISettingsScreenProps) => {
+  const [authInput, setAuthInput] = useState(window.localStorage.getItem("auth.token") ?? "");
+
+  useEffect(() => {
+    document.title = "VPlan | Settings";
+  });
+
+  const saveSettings = () => {
+    window.localStorage.setItem("storage.ls.version", props.currentStorageSchemeVersion);
+    window.localStorage.setItem("auth.token", authInput);
+    props.dismiss();
+  };
+
+  const handleResetSettingsButtonClick = () => {
+    const confirmation = window.confirm("Are you sure you want to remove all settings?");
+    if (confirmation) {
+      props.resetStorage();
+      updateInputFields();
+    }
+  };
+
+  const updateInputFields = () => {
+    setAuthInput(window.localStorage.getItem("auth.token") ?? "");
+  };
+
+  return (
+    <>
+      <h1 id="settingsHeading">Settings</h1>
+
+      <Stack id="settingsMenuStrip" direction="horizontal">
+        <Button onClick={saveSettings} variant="primary">
+          Save
+        </Button>
+        <Button onClick={props.dismiss} variant="secondary" className="ms-auto">
+          Cancel
+        </Button>
+      </Stack>
+
+      <ListGroup>
+        <ListGroup.Item>
+          <Form.Group>
+            <Form.Label>Authorization Token</Form.Label>
+            <Form.Control
+              plaintext={false}
+              type="password"
+              value={authInput}
+              placeholder="TmV2ZXIgZ29ubmEgZ2l2ZSB5b3UgdXA=" // "Never gonna give you up"
+              onChange={handleInputChange(setAuthInput)}
+            />
+            <Form.Text>The token used to authenticate with the external API.</Form.Text>
+          </Form.Group>
+        </ListGroup.Item>
+      </ListGroup>
+
+      <ButtonGroup id="settingsResetButtonContainer">
+        <Button id="settingsResetButton" onClick={handleResetSettingsButtonClick} variant="danger">
+          Reset Settings
+        </Button>
+      </ButtonGroup>
+    </>
+  );
+};
+
+export default SettingsScreen;

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -1,0 +1,3 @@
+#homeHeading {
+  margin: 0.5em;
+}

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -1,0 +1,15 @@
+#settingsHeading {
+  margin: 0.5em;
+}
+
+#settingsMenuStrip {
+  margin: 1em;
+}
+
+#settingsResetButtonContainer {
+  width: 100%;
+}
+
+#settingsResetButton {
+  margin: 1em;
+}

--- a/src/util/handleInputChange.ts
+++ b/src/util/handleInputChange.ts
@@ -1,0 +1,7 @@
+const handleInputChange = (hook: (newValue: string) => void) => {
+  return (updateEvent: React.ChangeEvent<HTMLInputElement>) => {
+    hook(updateEvent.currentTarget.value);
+  };
+};
+
+export default handleInputChange;


### PR DESCRIPTION
- feat: Add local storage for authentication
- gui: Move authentication from App to SettingsScreen
- gui(style): Add Heading to main view
- gui: Also dismiss success popups when a new request is made


<a href="https://gitpod.io/#https://github.com/kiriDevs/vplanweb/pull/9"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

