### PR TITLE
Move RequestFeebackAlert into own file, make errror heading Alert.Heading (instead of <strong>)

### DIFF
--- a/.devcontainer/Gitpod.Dockerfile
+++ b/.devcontainer/Gitpod.Dockerfile
@@ -18,7 +18,7 @@ RUN su -l gitpod -c "curl https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/i
 RUN su -l gitpod -c "chmod +x /setup/nvm/install.sh && /setup/nvm/install.sh"
 
 # Install node and npm via nvm
-RUN su -l gitpod -c ". /home/gitpod/.nvm/nvm.sh; cd /workspace/vplanweb; nvm install; nvm use --delete-prefix"
+RUN su -l gitpod -c ". /home/gitpod/.nvm/nvm.sh; nvm install v16.14.0; nvm use --delete-prefix v16.14.0"
 
 # Cache project dependencies for faster installation during first startup
 RUN su -l gitpod -c ". /home/gitpod/.nvm/nvm.sh; npm cache add @types/node @types/react @types/react-dom"

--- a/.devcontainer/Gitpod.Dockerfile
+++ b/.devcontainer/Gitpod.Dockerfile
@@ -18,7 +18,7 @@ RUN su -l gitpod -c "curl https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/i
 RUN su -l gitpod -c "chmod +x /setup/nvm/install.sh && /setup/nvm/install.sh"
 
 # Install node and npm via nvm
-RUN su -l gitpod -c ". /home/gitpod/.nvm/nvm.sh; nvm install v16.14.0; nvm use --delete-prefix v16.14.0"
+RUN su -l gitpod -c ". /home/gitpod/.nvm/nvm.sh; cd /workspace/vplanweb; nvm install; nvm use --delete-prefix"
 
 # Cache project dependencies for faster installation during first startup
 RUN su -l gitpod -c ". /home/gitpod/.nvm/nvm.sh; npm cache add @types/node @types/react @types/react-dom"

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -147,8 +147,7 @@ const App = () => {
                 }}
                 dismissible
               >
-                <strong>{apiError.message}</strong>
-                <br />
+                <Alert.Heading>{apiError.message}</Alert.Heading>
                 {apiError.description}
               </Alert>
             </>

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,7 +1,7 @@
 import axios from "axios";
 import { useEffect, useState } from "react";
-import { Alert, Button, Form, InputGroup, ListGroup, Spinner, Stack } from "react-bootstrap";
-import { APIError, makeApiErrorFromAxiosError } from "../types/api/APIErrorResponse";
+import { Button, Form, InputGroup, ListGroup, Spinner, Stack } from "react-bootstrap";
+import { makeApiErrorFromAxiosError } from "../types/api/APIErrorResponse";
 import APISubstitution from "../types/api/APISubstitution";
 import { makeSubstitutionFromAPI } from "../types/Substitution";
 import DateFormatter from "../util/DateFormatter";
@@ -9,6 +9,8 @@ import handleInputChange from "../util/handleInputChange";
 import SettingsScreen from "./SettingsScreen";
 import SubstitutionTable from "./SubstitutionTable";
 import { IoSend } from "react-icons/io5";
+import RequestFeedbackAlert from "./RequestFeedbackAlert";
+import RequestFeedback from "../types/RequestFeedback";
 
 import "../styles/home.css";
 
@@ -19,10 +21,7 @@ const App = () => {
   const [renderedSubstitutions, renderSubstitutions] = useState([]);
 
   const [date, setDate] = useState(DateFormatter.apiDateString(new Date()));
-
-  const [apiError, setApiError] = useState({} as APIError);
-  const [apiErrored, setApiErrored] = useState(false);
-  const [apiSuccess, setApiSuccess] = useState(false);
+  const [requestFeedback, setRequestFeedback] = useState({ type: "none" } as RequestFeedback);
 
   const [showingSettings, showSettings] = useState(false);
 
@@ -31,8 +30,7 @@ const App = () => {
       return;
     }
 
-    setApiErrored(false);
-    setApiSuccess(false);
+    setRequestFeedback({ type: "none" });
     setLoading(true);
     axios
       .get("https://api.chuangsheep.com/vplan", {
@@ -48,11 +46,10 @@ const App = () => {
         });
         renderSubstitutions(substitutions);
         setLoading(false);
-        setApiSuccess(true);
+        setRequestFeedback({ type: "success", entryCount: substitutions.length });
       })
       .catch((err) => {
-        setApiError(makeApiErrorFromAxiosError(err));
-        setApiErrored(true);
+        setRequestFeedback({ type: "error", error: makeApiErrorFromAxiosError(err) });
         setLoading(false);
       });
   };
@@ -137,35 +134,12 @@ const App = () => {
             </Form.Group>
           </Form>
 
-          {apiErrored && (
-            <>
-              <br />
-              <Alert
-                variant="danger"
-                onClose={() => {
-                  setApiErrored(false);
-                }}
-                dismissible
-              >
-                <Alert.Heading>{apiError.message}</Alert.Heading>
-                {apiError.description}
-              </Alert>
-            </>
-          )}
-          {apiSuccess && (
-            <>
-              <br />
-              <Alert
-                variant="success"
-                onClose={() => {
-                  setApiSuccess(false);
-                }}
-                dismissible
-              >
-                Successfully fetched {renderedSubstitutions.length} entries.
-              </Alert>
-            </>
-          )}
+          <RequestFeedbackAlert
+            dismiss={() => {
+              setRequestFeedback({ type: "none" });
+            }}
+            feedback={requestFeedback}
+          />
         </ListGroup.Item>
 
         <ListGroup.Item>

--- a/src/components/RequestFeedbackAlert.tsx
+++ b/src/components/RequestFeedbackAlert.tsx
@@ -1,0 +1,37 @@
+import Alert from "react-bootstrap/Alert";
+import RequestFeedback from "../types/RequestFeedback";
+
+interface IRequestFeedbackAlertProps {
+  dismiss: () => void;
+  feedback: RequestFeedback;
+}
+
+const RequestFeedbackAlert = (props: IRequestFeedbackAlertProps) => {
+  if (props.feedback.type === "none") {
+    return <></>;
+  }
+
+  return (
+    <>
+      <br />
+      <Alert
+        variant={props.feedback.type === "error" ? "danger" : props.feedback.type}
+        dismissible
+        onClose={props.dismiss}
+      >
+        {props.feedback.type === "success" ? (
+          <span>
+            Successfully fetched <strong>{props.feedback.entryCount}</strong> entries.
+          </span>
+        ) : (
+          <>
+            <Alert.Heading>{props.feedback.error.message}</Alert.Heading>
+            {props.feedback.error.description}
+          </>
+        )}
+      </Alert>
+    </>
+  );
+};
+
+export default RequestFeedbackAlert;

--- a/src/types/RequestFeedback.ts
+++ b/src/types/RequestFeedback.ts
@@ -1,0 +1,14 @@
+import { APIError } from "./api/APIErrorResponse";
+
+type RequestFeedback =
+  | {
+      type: "success";
+      entryCount: number;
+    }
+  | {
+      type: "error";
+      error: APIError;
+    }
+  | { type: "none" };
+
+export default RequestFeedback;


### PR DESCRIPTION
- style: Make error alert heading an Alert.Heading
- dev(gp): Make use of nvmrc during node install for GitPod
- Revert "dev(gp): Make use of nvmrc during node install for GitPod"
- style: Move RequestFeedback Alert into its own file


<a href="https://gitpod.io/#https://github.com/kiriDevs/vplanweb/pull/14"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

