### PR TITLE
Install GitHub CLI (`gh`) in GitPod

### DIFF
--- a/.devcontainer/Gitpod.Dockerfile
+++ b/.devcontainer/Gitpod.Dockerfile
@@ -19,6 +19,7 @@ WORKDIR /setup/gh
 RUN wget https://github.com/cli/cli/releases/download/v2.6.0/gh_2.6.0_linux_amd64.tar.gz
 RUN tar -xzvf /setup/gh/gh_2.6.0_linux_amd64.tar.gz
 # Merge files into fs-root
+RUN rm /setup/gh/gh_2.6.0_linux_amd64/LICENSE
 RUN rsync -a /setup/gh/gh_2.6.0_linux_amd64/* /
 
 # Set up NVM

--- a/.devcontainer/Gitpod.Dockerfile
+++ b/.devcontainer/Gitpod.Dockerfile
@@ -20,7 +20,7 @@ RUN wget https://github.com/cli/cli/releases/download/v2.6.0/gh_2.6.0_linux_amd6
 RUN tar -xzvf /setup/gh/gh_2.6.0_linux_amd64.tar.gz
 # Merge files into fs-root
 RUN rm /setup/gh/gh_2.6.0_linux_amd64/LICENSE
-RUN rsync -a /setup/gh/gh_2.6.0_linux_amd64/* /
+RUN rsync /setup/gh/gh_2.6.0_linux_amd64/* /
 
 # Set up NVM
 RUN mkdir -p /setup/nvm && chown -R gitpod:gitpod /setup/nvm

--- a/.devcontainer/Gitpod.Dockerfile
+++ b/.devcontainer/Gitpod.Dockerfile
@@ -19,7 +19,7 @@ WORKDIR /setup/gh
 RUN wget https://github.com/cli/cli/releases/download/v2.6.0/gh_2.6.0_linux_amd64.tar.gz
 RUN tar -xzvf /setup/gh/gh_2.6.0_linux_amd64.tar.gz
 # Merge files into fs-root
-RUN rsync /setup/gh/gh_2.6.0_linux_amd64/* /
+RUN rsync -a /setup/gh/gh_2.6.0_linux_amd64/* /
 
 # Set up NVM
 RUN mkdir -p /setup/nvm && chown -R gitpod:gitpod /setup/nvm

--- a/.devcontainer/Gitpod.Dockerfile
+++ b/.devcontainer/Gitpod.Dockerfile
@@ -12,6 +12,15 @@ RUN tar -xzvf /setup/nvim/nvim-linux64.tar.gz
 # Merge files into fs-root
 RUN rsync /setup/nvim/nvim-linux64/* /
 
+# Setup GitHub CLI
+RUN mkdir -p /setup/gh/
+WORKDIR /setup/gh
+# Download and extract archive
+RUN wget https://github.com/cli/cli/releases/download/v2.6.0/gh_2.6.0_linux_amd64.tar.gz
+RUN tar -xzvf /setup/gh/gh_2.6.0_linux_amd64.tar.gz
+# Merge files into fs-root
+RUN rsync /setup/gh/gh_2.6.0_linux_amd64/* /
+
 # Set up NVM
 RUN mkdir -p /setup/nvm && chown -R gitpod:gitpod /setup/nvm
 RUN su -l gitpod -c "curl https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh -o /setup/nvm/install.sh"


### PR DESCRIPTION
GitPod doesn't include GitHub CLI by default

<a href="https://gitpod.io/#https://github.com/kiriDevs/vplanweb/pull/16"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

