### PR TITLE
feat: Highlight relevant entries in the main views table

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -57,6 +57,7 @@ const App = () => {
   const initializeStorage = () => {
     window.localStorage.clear();
     window.localStorage.setItem("storage.ls.version", CURRENT_LOCALSTORAGE_SCHEMA_VERSION);
+    window.localStorage.setItem("auth.token", "");
   };
 
   // Validating localStorage when the App component is mounted

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -68,10 +68,13 @@ const App = () => {
     } else if (storageVersion === CURRENT_LOCALSTORAGE_SCHEMA_VERSION) {
       // The storage is on the latest schema version - we're done here
       return;
-      /*
-    } else if (storageVersion === "0.0") {
+    } else if (storageVersion === "1.0") {
+      // YAAAY let's migrate from version 1.0
+      window.localStorage.setItem("filter.class", "");
+      window.localStorage.setItem("filter.subjects", JSON.stringify([]));
+
+      window.localStorage.setItem("storage.ls.version", "1.1");
       alert("Your localStorage was migrated to a new schema version!");
-    */
     } else {
       alert(
         "Your localStorage is outdated and its version is no longer supported for migration. " +

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -14,7 +14,7 @@ import RequestFeedback from "../types/RequestFeedback";
 
 import "../styles/home.css";
 
-const CURRENT_LOCALSTORAGE_SCHEMA_VERSION = "1.0";
+const CURRENT_LOCALSTORAGE_SCHEMA_VERSION = "1.1";
 
 const App = () => {
   const [loading, setLoading] = useState(false);

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -58,6 +58,8 @@ const App = () => {
     window.localStorage.clear();
     window.localStorage.setItem("storage.ls.version", CURRENT_LOCALSTORAGE_SCHEMA_VERSION);
     window.localStorage.setItem("auth.token", "");
+    window.localStorage.setItem("filter.class", "");
+    window.localStorage.setItem("filter.subjects", JSON.stringify([]));
   };
 
   // Validating localStorage when the App component is mounted

--- a/src/components/SettingsScreen.tsx
+++ b/src/components/SettingsScreen.tsx
@@ -19,7 +19,11 @@ const SettingsScreen = (props: ISettingsScreenProps) => {
 
   const saveSettings = () => {
     window.localStorage.setItem("storage.ls.version", props.currentStorageSchemeVersion);
+
     window.localStorage.setItem("auth.token", authInput);
+    window.localStorage.setItem("filter.class", classInput);
+    window.localStorage.setItem("filter.subjects", JSON.stringify(subjectsInput.filter((v: string) => v !== "")));
+
     props.dismiss();
   };
 

--- a/src/components/SettingsScreen.tsx
+++ b/src/components/SettingsScreen.tsx
@@ -15,7 +15,9 @@ const SettingsScreen = (props: ISettingsScreenProps) => {
   const [authInput, setAuthInput] = useState(window.localStorage.getItem("auth.token") ?? "");
 
   const [classInput, setClassInput] = useState(window.localStorage.getItem("filter.class") ?? "");
-  const [subjectsInput, setSubjectsInput] = useState(JSON.parse(window.localStorage.getItem("filter.subjects") ?? "[]"));
+  const [subjectsInput, setSubjectsInput] = useState(
+    JSON.parse(window.localStorage.getItem("filter.subjects") ?? "[]")
+  );
 
   useEffect(() => {
     document.title = "VPlan | Settings";

--- a/src/components/SettingsScreen.tsx
+++ b/src/components/SettingsScreen.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Form, ListGroup, Button, Stack, ButtonGroup } from "react-bootstrap";
+import { Form, ListGroup, Button, Stack, ButtonGroup, InputGroup, Alert } from "react-bootstrap";
 
 import "../styles/settings.css";
 import handleInputChange from "../util/handleInputChange";
@@ -12,6 +12,9 @@ interface ISettingsScreenProps {
 
 const SettingsScreen = (props: ISettingsScreenProps) => {
   const [authInput, setAuthInput] = useState(window.localStorage.getItem("auth.token") ?? "");
+
+  const [classInput, setClassInput] = useState(window.localStorage.getItem("filter.class") ?? "");
+  const [subjectsInput, setSubjectsInput] = useState(JSON.parse(window.localStorage.getItem("filter.subjects") ?? ""));
 
   useEffect(() => {
     document.title = "VPlan | Settings";
@@ -37,6 +40,18 @@ const SettingsScreen = (props: ISettingsScreenProps) => {
 
   const updateInputFields = () => {
     setAuthInput(window.localStorage.getItem("auth.token") ?? "");
+    setClassInput(window.localStorage.getItem("filter.class") ?? "");
+  };
+
+  const setSubjectInputValue = (index: number) =>
+    handleInputChange((newValue: string) => {
+      const newSubjectsInput = [...subjectsInput];
+      newSubjectsInput[index] = newValue;
+      setSubjectsInput(newSubjectsInput);
+    });
+
+  const handleSubjectDeleteButtonClick = (index: number) => () => {
+    setSubjectsInput(subjectsInput.filter((_: string, inx: number) => inx !== index));
   };
 
   return (
@@ -65,6 +80,67 @@ const SettingsScreen = (props: ISettingsScreenProps) => {
             />
             <Form.Text>The token used to authenticate with the external API.</Form.Text>
           </Form.Group>
+        </ListGroup.Item>
+
+        <ListGroup.Item>
+          <Form.Group>
+            <Form.Label>Your class</Form.Label>
+            <Form.Control
+              plaintext={false}
+              type="text"
+              value={classInput}
+              placeholder="9a / EFb / Q1"
+              onChange={handleInputChange(setClassInput)}
+            />
+          </Form.Group>
+        </ListGroup.Item>
+
+        <ListGroup.Item>
+          <p>Your subjects</p>
+          <Form
+            onSubmit={(e) => {
+              // Do absolutely nothing
+              e.preventDefault();
+            }}
+          >
+            <Stack direction="vertical" gap={3}>
+              {subjectsInput.map((value: string, index: number) => (
+                <Form.Group>
+                  <InputGroup>
+                    <Form.Control
+                      plaintext={false}
+                      type="text"
+                      value={subjectsInput[index]}
+                      placeholder="E1 / erB / CH"
+                      onChange={setSubjectInputValue(index)}
+                    />
+                    <Button variant="danger" onClick={handleSubjectDeleteButtonClick(index)}>
+                      X
+                    </Button>
+                  </InputGroup>
+                </Form.Group>
+              ))}
+
+              <Button
+                onClick={() => {
+                  const newSubjectsInput = [...subjectsInput];
+                  newSubjectsInput.push("");
+                  setSubjectsInput(newSubjectsInput);
+                }}
+              >
+                + Add another subject
+              </Button>
+
+              <Alert variant="secondary">
+                <strong>Note:</strong> Make sure to enter your subjects with the name that they appear with on the
+                substitution plans of the school. In some cases, this representation might differ from what's listed on
+                the timetable or the course choice lists.
+                <br />
+                <br />
+                <strong>Example:</strong> <code>SW/WI</code> instead of <code>SW</code>
+              </Alert>
+            </Stack>
+          </Form>
         </ListGroup.Item>
       </ListGroup>
 

--- a/src/components/SettingsScreen.tsx
+++ b/src/components/SettingsScreen.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { Form, ListGroup, Button, Stack, ButtonGroup, InputGroup, Alert } from "react-bootstrap";
+import { AiFillDelete, AiOutlinePlus, AiOutlineExclamation } from "react-icons/ai";
 
 import "../styles/settings.css";
 import handleInputChange from "../util/handleInputChange";
@@ -115,7 +116,7 @@ const SettingsScreen = (props: ISettingsScreenProps) => {
                       onChange={setSubjectInputValue(index)}
                     />
                     <Button variant="danger" onClick={handleSubjectDeleteButtonClick(index)}>
-                      X
+                      <AiFillDelete />
                     </Button>
                   </InputGroup>
                 </Form.Group>
@@ -128,7 +129,7 @@ const SettingsScreen = (props: ISettingsScreenProps) => {
                   setSubjectsInput(newSubjectsInput);
                 }}
               >
-                + Add another subject
+                <AiOutlinePlus /> Add another subject
               </Button>
 
               <Alert variant="secondary">
@@ -146,7 +147,7 @@ const SettingsScreen = (props: ISettingsScreenProps) => {
 
       <ButtonGroup id="settingsResetButtonContainer">
         <Button id="settingsResetButton" onClick={handleResetSettingsButtonClick} variant="danger">
-          Reset Settings
+          <AiOutlineExclamation /> Reset Settings
         </Button>
       </ButtonGroup>
     </>

--- a/src/components/SettingsScreen.tsx
+++ b/src/components/SettingsScreen.tsx
@@ -15,7 +15,7 @@ const SettingsScreen = (props: ISettingsScreenProps) => {
   const [authInput, setAuthInput] = useState(window.localStorage.getItem("auth.token") ?? "");
 
   const [classInput, setClassInput] = useState(window.localStorage.getItem("filter.class") ?? "");
-  const [subjectsInput, setSubjectsInput] = useState(JSON.parse(window.localStorage.getItem("filter.subjects") ?? ""));
+  const [subjectsInput, setSubjectsInput] = useState(JSON.parse(window.localStorage.getItem("filter.subjects") ?? "[]"));
 
   useEffect(() => {
     document.title = "VPlan | Settings";

--- a/src/components/SubstitutionTable.tsx
+++ b/src/components/SubstitutionTable.tsx
@@ -6,29 +6,38 @@ interface ISubstitutionTableProps {
   substitutions: Substitution[];
 }
 
-const SubstitutionTable = (props: ISubstitutionTableProps) => (
-  <Table>
-    <thead>
-      <tr>
-        <th>Period</th>
-        <th>Substitute</th>
-        <th>Subject</th>
-        <th>Teacher</th>
-        <th>Class</th>
-        <th>Room</th>
-        <th>Note</th>
-      </tr>
-    </thead>
-    <tbody>
-      {props.substitutions.map((substitution: Substitution) => (
-        <SubstitutionTableRow
-          key={`#-st-str-${substitution.period}${substitution.absent}`}
-          substitution={substitution}
-          highlighted={false}
-        />
-      ))}
-    </tbody>
-  </Table>
-);
+const SubstitutionTable = (props: ISubstitutionTableProps) => {
+  const isRelevant = (substitution: Substitution) => {
+    return (
+      substitution.class === window.localStorage.getItem("filter.class") &&
+      JSON.parse(window.localStorage.getItem("filter.subjects") ?? "[]").includes(substitution.subject)
+    );
+  };
+
+  return (
+    <Table>
+      <thead>
+        <tr>
+          <th>Period</th>
+          <th>Substitute</th>
+          <th>Subject</th>
+          <th>Teacher</th>
+          <th>Class</th>
+          <th>Room</th>
+          <th>Note</th>
+        </tr>
+      </thead>
+      <tbody>
+        {props.substitutions.map((substitution: Substitution) => (
+          <SubstitutionTableRow
+            key={`#-st-str-${substitution.period}${substitution.absent}`}
+            substitution={substitution}
+            highlighted={isRelevant(substitution)}
+          />
+        ))}
+      </tbody>
+    </Table>
+  );
+};
 
 export default SubstitutionTable;

--- a/src/components/SubstitutionTable.tsx
+++ b/src/components/SubstitutionTable.tsx
@@ -22,7 +22,7 @@ const SubstitutionTable = (props: ISubstitutionTableProps) => (
     <tbody>
       {props.substitutions.map((substitution: Substitution) => (
         <SubstitutionTableRow
-          key={`#-st-str-${substitution.period}${substitution.class}${substitution.subject}`}
+          key={`#-st-str-${substitution.period}${substitution.absent}`}
           substitution={substitution}
         />
       ))}

--- a/src/components/SubstitutionTable.tsx
+++ b/src/components/SubstitutionTable.tsx
@@ -24,6 +24,7 @@ const SubstitutionTable = (props: ISubstitutionTableProps) => (
         <SubstitutionTableRow
           key={`#-st-str-${substitution.period}${substitution.absent}`}
           substitution={substitution}
+          highlighted={false}
         />
       ))}
     </tbody>

--- a/src/components/SubstitutionTableRow.tsx
+++ b/src/components/SubstitutionTableRow.tsx
@@ -2,20 +2,19 @@ import { Substitution } from "../types/Substitution";
 
 interface ISubstitutionTableRowProps {
   substitution: Substitution;
+  highlighted: boolean;
 }
 
-const SubstitutionTableRow = (props: ISubstitutionTableRowProps) => {
-  return (
-    <tr>
-      <td>{props.substitution.period}</td>
-      <td>{props.substitution.substitute}</td>
-      <td>{props.substitution.subject}</td>
-      <td>{props.substitution.absent}</td>
-      <td>{props.substitution.class}</td>
-      <td>{props.substitution.room}</td>
-      <td>{props.substitution.note}</td>
-    </tr>
-  );
-};
+const SubstitutionTableRow = (props: ISubstitutionTableRowProps) => (
+  <tr className={props.highlighted ? "alert-primary text-black" : ""}>
+    <td>{props.substitution.period}</td>
+    <td>{props.substitution.substitute}</td>
+    <td>{props.substitution.subject}</td>
+    <td>{props.substitution.absent}</td>
+    <td>{props.substitution.class}</td>
+    <td>{props.substitution.room}</td>
+    <td>{props.substitution.note}</td>
+  </tr>
+);
 
 export default SubstitutionTableRow;


### PR DESCRIPTION
Also includes some minor style changes and UI improvements (icons for the SettingsScreen)

- fix: Change key prop format for rows in SubstitutionTable
- feat: Add logic for highlighting table rows
- storage(ls): Add migration logic (1.0 -> 1.1)
- chore(storage(ls)): Switch to localstorage 1.1
- fix: Add auth.token to storage init
- storage(ls): Add filter.* to storage init
- storage(ls): Add filter.* to settings save
- feat: Add filter configuration to settings
- ui: Add icons to settings
- fix: Use "[]" as subjects default value
- feat(ui): Highlight relevant substitutions in the list
- style: Run Prettier on SettingsScreen.tsx
