### PR TITLE
feat: Filter switch; style: Optimize imports

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -5,7 +5,7 @@ import { makeApiErrorFromAxiosError } from "../types/api/APIErrorResponse";
 import APISubstitution from "../types/api/APISubstitution";
 import { makeSubstitutionFromAPI } from "../types/Substitution";
 import DateFormatter from "../util/DateFormatter";
-import handleInputChange from "../util/handleInputChange";
+import { handleCheckoxChange, handleInputChange } from "../util/handleInputChange";
 import SettingsScreen from "./SettingsScreen";
 import SubstitutionTable from "./SubstitutionTable";
 import { IoSend } from "react-icons/io5";
@@ -14,7 +14,7 @@ import RequestFeedback from "../types/RequestFeedback";
 
 import "../styles/home.css";
 
-const CURRENT_LOCALSTORAGE_SCHEMA_VERSION = "1.1";
+const CURRENT_LOCALSTORAGE_SCHEMA_VERSION = "1.2";
 
 const App = () => {
   const [loading, setLoading] = useState(false);
@@ -22,6 +22,7 @@ const App = () => {
 
   const [date, setDate] = useState(DateFormatter.apiDateString(new Date()));
   const [requestFeedback, setRequestFeedback] = useState({ type: "none" } as RequestFeedback);
+  const [filteringRelevant, filterRelevant] = useState(JSON.parse(window.localStorage.getItem("filter") ?? "false"));
 
   const [showingSettings, showSettings] = useState(false);
 
@@ -60,6 +61,12 @@ const App = () => {
     window.localStorage.setItem("auth.token", "");
     window.localStorage.setItem("filter.class", "");
     window.localStorage.setItem("filter.subjects", JSON.stringify([]));
+    window.localStorage.setItem("filter", JSON.stringify(false));
+  };
+
+  const handleFilterSwitch = (newValue: boolean) => {
+    filterRelevant(newValue);
+    window.localStorage.setItem("filter", JSON.stringify(newValue));
   };
 
   // Validating localStorage when the App component is mounted
@@ -75,8 +82,15 @@ const App = () => {
       // YAAAY let's migrate from version 1.0
       window.localStorage.setItem("filter.class", "");
       window.localStorage.setItem("filter.subjects", JSON.stringify([]));
+      window.localStorage.setItem("filter", JSON.stringify(false));
 
-      window.localStorage.setItem("storage.ls.version", "1.1");
+      window.localStorage.setItem("storage.ls.version", "1.2");
+      alert("Your localStorage was migrated to a new schema version!");
+    } else if (storageVersion === "1.1") {
+      // Migrate from version 1.1
+      window.localStorage.setItem("filter", JSON.stringify(false));
+
+      window.localStorage.setItem("storage.ls.version", "1.2");
       alert("Your localStorage was migrated to a new schema version!");
     } else {
       alert(
@@ -144,6 +158,12 @@ const App = () => {
               </Stack>
               <Form.Text>The date to request the VPlan for</Form.Text>
             </Form.Group>
+            <br />
+            <Form.Switch
+              label="Only display relevant entries"
+              checked={filteringRelevant}
+              onChange={handleCheckoxChange(handleFilterSwitch)}
+            />
           </Form>
 
           <RequestFeedbackAlert
@@ -155,7 +175,7 @@ const App = () => {
         </ListGroup.Item>
 
         <ListGroup.Item>
-          <SubstitutionTable substitutions={renderedSubstitutions} />
+          <SubstitutionTable substitutions={renderedSubstitutions} relevantOnly={filteringRelevant} />
         </ListGroup.Item>
 
         <ListGroup.Item>

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,6 +1,11 @@
 import axios from "axios";
 import { useEffect, useState } from "react";
-import { Button, Form, InputGroup, ListGroup, Spinner, Stack } from "react-bootstrap";
+import Button from "react-bootstrap/Button";
+import Form from "react-bootstrap/Form";
+import InputGroup from "react-bootstrap/InputGroup";
+import ListGroup from "react-bootstrap/ListGroup";
+import Spinner from "react-bootstrap/Spinner";
+import Stack from "react-bootstrap/Stack";
 import { makeApiErrorFromAxiosError } from "../types/api/APIErrorResponse";
 import APISubstitution from "../types/api/APISubstitution";
 import { makeSubstitutionFromAPI } from "../types/Substitution";

--- a/src/components/SettingsScreen.tsx
+++ b/src/components/SettingsScreen.tsx
@@ -3,7 +3,7 @@ import { Form, ListGroup, Button, Stack, ButtonGroup, InputGroup, Alert } from "
 import { AiFillDelete, AiOutlinePlus, AiOutlineExclamation } from "react-icons/ai";
 
 import "../styles/settings.css";
-import handleInputChange from "../util/handleInputChange";
+import { handleInputChange } from "../util/handleInputChange";
 
 interface ISettingsScreenProps {
   dismiss: () => void;

--- a/src/components/SettingsScreen.tsx
+++ b/src/components/SettingsScreen.tsx
@@ -1,5 +1,11 @@
 import { useEffect, useState } from "react";
-import { Form, ListGroup, Button, Stack, ButtonGroup, InputGroup, Alert } from "react-bootstrap";
+import Alert from "react-bootstrap/Alert";
+import Button from "react-bootstrap/Button";
+import ButtonGroup from "react-bootstrap/ButtonGroup";
+import Form from "react-bootstrap/Form";
+import InputGroup from "react-bootstrap/InputGroup";
+import ListGroup from "react-bootstrap/ListGroup";
+import Stack from "react-bootstrap/Stack";
 import { AiFillDelete, AiOutlinePlus, AiOutlineExclamation } from "react-icons/ai";
 
 import "../styles/settings.css";

--- a/src/components/SubstitutionTable.tsx
+++ b/src/components/SubstitutionTable.tsx
@@ -4,6 +4,7 @@ import SubstitutionTableRow from "./SubstitutionTableRow";
 
 interface ISubstitutionTableProps {
   substitutions: Substitution[];
+  relevantOnly: boolean;
 }
 
 const SubstitutionTable = (props: ISubstitutionTableProps) => {
@@ -28,13 +29,15 @@ const SubstitutionTable = (props: ISubstitutionTableProps) => {
         </tr>
       </thead>
       <tbody>
-        {props.substitutions.map((substitution: Substitution) => (
-          <SubstitutionTableRow
-            key={`#-st-str-${substitution.period}${substitution.absent}`}
-            substitution={substitution}
-            highlighted={isRelevant(substitution)}
-          />
-        ))}
+        {props.substitutions
+          .filter((substitution: Substitution) => !props.relevantOnly || isRelevant(substitution))
+          .map((substitution: Substitution) => (
+            <SubstitutionTableRow
+              key={`#-st-str-${substitution.period}${substitution.absent}`}
+              substitution={substitution}
+              highlighted={!props.relevantOnly && isRelevant(substitution)}
+            />
+          ))}
       </tbody>
     </Table>
   );

--- a/src/util/handleInputChange.ts
+++ b/src/util/handleInputChange.ts
@@ -4,4 +4,10 @@ const handleInputChange = (hook: (newValue: string) => void) => {
   };
 };
 
-export default handleInputChange;
+const handleCheckoxChange = (hook: (newValue: boolean) => void) => {
+  return (updateEvent: React.ChangeEvent<HTMLInputElement>) => {
+    hook(updateEvent.currentTarget.checked);
+  };
+};
+
+export { handleInputChange, handleCheckoxChange };


### PR DESCRIPTION
- feat: Add logic to only display relevant entries
- feat: Add standard logic for handling checkboxes
- ui: Add switch to toggle filter mode
- storage(ls): Prepare for localStorage v1.2
- storage(ls): Modify migration logic from 1.0 to go to 1.2
- ui: Link filter switch to localStorage
- fix(storage): Do not save booleans as strings
- chore: Switch to storage v1.2
- style: Remove unnecessary import
- style: Optimize imports in App
- style: Optimize imports in SettingsScreen


<a href="https://gitpod.io/#https://github.com/kiriDevs/vplanweb/pull/19"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

