### PR TITLE
Update `document.title` more often

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -21,7 +21,6 @@ const App = () => {
     <SettingsScreen
       dismiss={() => {
         showSettings(false);
-        document.title = "VPlan | Home";
       }}
     />
   ) : (

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -13,6 +13,7 @@ const App = () => {
   const [renderedSubstitutions, renderSubstitutions] = useState([]);
 
   useEffect(() => {
+    document.title = "VPlan | Home";
     StorageManager.startup();
   }, []);
 
@@ -20,6 +21,7 @@ const App = () => {
     <SettingsScreen
       dismiss={() => {
         showSettings(false);
+        document.title = "VPlan | Home";
       }}
     />
   ) : (

--- a/src/components/HomeScreen.tsx
+++ b/src/components/HomeScreen.tsx
@@ -13,7 +13,7 @@ import SubstitutionTable from "./SubstitutionTable";
 import { IoSend } from "react-icons/io5";
 import RequestFeedbackAlert from "./RequestFeedbackAlert";
 import RequestFeedback from "../types/RequestFeedback";
-import { useState, Dispatch, SetStateAction } from "react";
+import { useState, Dispatch, SetStateAction, useEffect } from "react";
 import DateFormatter from "../util/DateFormatter";
 
 interface IHomeScreenProps {
@@ -28,6 +28,12 @@ const HomeScreen = (props: IHomeScreenProps) => {
   const [date, setDate] = useState(DateFormatter.apiDateString(new Date()));
   const [requestFeedback, setRequestFeedback] = useState({ type: "none" } as RequestFeedback);
   const [filteringRelevant, filterRelevant] = useState(JSON.parse(window.localStorage.getItem("filter") ?? "false"));
+
+  useEffect(() => {
+    if (loading) {
+      document.title = "VPlan | Loading...";
+    }
+  }, [loading]);
 
   const makeRequest = () => {
     if (loading) {
@@ -51,6 +57,7 @@ const HomeScreen = (props: IHomeScreenProps) => {
         props.renderSubstitutions(substitutions);
         setLoading(false);
         setRequestFeedback({ type: "success", entryCount: substitutions.length });
+        document.title = "VPlan | " + res.data.date;
       })
       .catch((err) => {
         setRequestFeedback({ type: "error", error: makeApiErrorFromAxiosError(err) });

--- a/src/components/SettingsScreen.tsx
+++ b/src/components/SettingsScreen.tsx
@@ -25,7 +25,13 @@ const SettingsScreen = (props: ISettingsScreenProps) => {
   );
 
   useEffect(() => {
+    const oldTitle = document.title;
     document.title = "VPlan | Settings";
+
+    // Return a clean up function to return the title to the old state
+    return () => {
+      document.title = oldTitle;
+    };
   });
 
   const saveSettings = () => {


### PR DESCRIPTION
## Known Issues

When bringing up `SettingsScreen` while the title is `VPlan | Loading...` it will go back to that even though the page is not loading anymore.

However, I deemed this solution to be the best balance between functionality and problems (by far - I mean, how often would someone press Settings while loading their content on the main page? And that's the only issue in this system.)

Sure, I could modify the whole structure to make this even better, and I probably will at some point in the future, but for now this is *good enough*.


## Commits

- feat: Add title updates on navigation and requests
- fix: Pass a clean up function from SettingsScreen useEffect

## Issue Mentions

- Closes #24


<a href="https://gitpod.io/#https://github.com/kiriDevs/vplanweb/pull/26"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

