### PR TITLE
fix: Trim course entries before checking if they're !== ""

### DIFF
--- a/src/components/SettingsScreen.tsx
+++ b/src/components/SettingsScreen.tsx
@@ -39,7 +39,10 @@ const SettingsScreen = (props: ISettingsScreenProps) => {
 
     window.localStorage.setItem("auth.token", authInput);
     window.localStorage.setItem("filter.class", classInput);
-    window.localStorage.setItem("filter.subjects", JSON.stringify(subjectsInput.filter((v: string) => v !== "")));
+    window.localStorage.setItem(
+      "filter.subjects",
+      JSON.stringify(subjectsInput.filter((v: string) => v.trim() !== ""))
+    );
 
     props.dismiss();
   };


### PR DESCRIPTION
This excludes " ", "  ", "   ", etc. from the list of possible entries. Because that makes sense.


<a href="https://gitpod.io/#https://github.com/kiriDevs/vplanweb/pull/30"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

