### PR TITLE
Preload data from API on load

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -30,8 +30,6 @@ const App = () => {
             showSettings={() => {
               showSettings(true);
             }}
-            renderedSubstitutions={renderedSubstitutions}
-            renderSubstitutions={renderSubstitutions as Dispatch<SetStateAction<Substitution[]>>}
           />
         )}
       </RESTContext.Provider>

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -4,6 +4,9 @@ import HomeScreen from "./HomeScreen";
 import SettingsScreen from "./SettingsScreen";
 import { shared as StorageManager } from "../util/StorageManager";
 
+import REST from "../services/rest/REST";
+import RESTContext from "../services/rest/RESTContext";
+
 import "../styles/general.css";
 
 const App = () => {
@@ -13,18 +16,26 @@ const App = () => {
     StorageManager.startup();
   }, []);
 
-  return showingSettings ? (
-    <SettingsScreen
-      dismiss={() => {
-        showSettings(false);
-      }}
-    />
-  ) : (
-    <HomeScreen
-      showSettings={() => {
-        showSettings(true);
-      }}
-    />
+  return (
+    <>
+      <RESTContext.Provider value={new REST(window.localStorage.getItem("auth.token") || "")}>
+        {showingSettings ? (
+          <SettingsScreen
+            dismiss={() => {
+              showSettings(false);
+            }}
+          />
+        ) : (
+          <HomeScreen
+            showSettings={() => {
+              showSettings(true);
+            }}
+            renderedSubstitutions={renderedSubstitutions}
+            renderSubstitutions={renderSubstitutions as Dispatch<SetStateAction<Substitution[]>>}
+          />
+        )}
+      </RESTContext.Provider>
+    </>
   );
 };
 

--- a/src/components/DatePicker.tsx
+++ b/src/components/DatePicker.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import DropdownButton from "react-bootstrap/esm/DropdownButton";
 import DropdownItem from "react-bootstrap/esm/DropdownItem";
 import DateFormatter from "../util/DateFormatter";
-import { isWeekend } from "../util/dateUtil";
+import { getNextSchooldays } from "../util/dateUtil";
 
 interface IDatePickerProps {
   select: (newValue: Date) => void;
@@ -14,20 +14,9 @@ const DatePicker = (props: IDatePickerProps) => {
   const [selection, select] = useState(options[0]);
 
   useEffect(() => {
-    let genOptions = [];
-    let itDate = new Date();
-
-    while (genOptions.length < props.maxDays) {
-      if (!isWeekend(itDate)) {
-        genOptions.push(new Date(itDate));
-      }
-
-      itDate.setDate(itDate.getDate() + 1);
-    }
-
-    setOptions(genOptions);
-    select(genOptions[0]);
-    props.select(genOptions[0]);
+    const _options = getNextSchooldays(3);
+    setOptions(_options);
+    select(_options[0]);
   }, [props.maxDays]);
 
   return (

--- a/src/components/HomeScreen.tsx
+++ b/src/components/HomeScreen.tsx
@@ -53,7 +53,6 @@ const HomeScreen = (props: IHomeScreenProps) => {
   useEffect(() => {
     dateOptions.forEach((option: Date) => {
       const dateString = DateFormatter.apiDateString(option);
-      console.log(dateString);
 
       rest
         .fetchPlan(option)

--- a/src/components/HomeScreen.tsx
+++ b/src/components/HomeScreen.tsx
@@ -16,7 +16,7 @@ import DatePicker from "./DatePicker";
 import { getNextSchooldays } from "../util/dateUtil";
 import DateFormatter from "../util/DateFormatter";
 import RESTContext from "../services/rest/RESTContext";
-import { Alert } from "react-bootstrap";
+import Alert from "react-bootstrap/Alert";
 
 import { Button, Form, ListGroup, Spinner, Stack } from "react-bootstrap";
 import { FilterContextProvider } from "../context/FilterContext";

--- a/src/components/HomeScreen.tsx
+++ b/src/components/HomeScreen.tsx
@@ -1,8 +1,3 @@
-import Button from "react-bootstrap/Button";
-import Form from "react-bootstrap/Form";
-import ListGroup from "react-bootstrap/ListGroup";
-import Spinner from "react-bootstrap/Spinner";
-import Stack from "react-bootstrap/Stack";
 import { APIError } from "../types/api/APIError";
 import { Substitution } from "../types/Substitution";
 import { handleCheckboxChange } from "../util/handleInputChange";

--- a/src/components/HomeScreen.tsx
+++ b/src/components/HomeScreen.tsx
@@ -200,6 +200,7 @@ const HomeScreen = (props: IHomeScreenProps) => {
             <SubstitutionTable
               substitutions={data[DateFormatter.apiDateString(selection)] as Substitution[]}
               relevantOnly={filteringRelevant}
+              ignoreSubjects={ignoringSubjects}
             />
           )}
         </ListGroup.Item>

--- a/src/components/HomeScreen.tsx
+++ b/src/components/HomeScreen.tsx
@@ -53,7 +53,7 @@ const HomeScreen = (props: IHomeScreenProps) => {
   useEffect(() => {
     dateOptions.forEach((option: Date) => {
       const dateString = DateFormatter.apiDateString(option);
-      setData((old) => ({ ...old }));
+
       rest
         .fetchPlan(option)
         .then((entries: Substitution[]) => {

--- a/src/components/HomeScreen.tsx
+++ b/src/components/HomeScreen.tsx
@@ -76,7 +76,7 @@ const HomeScreen = (props: IHomeScreenProps) => {
     } else {
       document.title = "VPlan | " + t("title");
     }
-  }, [loading, tc]);
+  }, [loading, tc, t]);
 
   const makeRequest = () => {
     if (loading) {

--- a/src/components/HomeScreen.tsx
+++ b/src/components/HomeScreen.tsx
@@ -53,6 +53,7 @@ const HomeScreen = (props: IHomeScreenProps) => {
   useEffect(() => {
     dateOptions.forEach((option: Date) => {
       const dateString = DateFormatter.apiDateString(option);
+      console.log(dateString);
 
       rest
         .fetchPlan(option)
@@ -68,7 +69,8 @@ const HomeScreen = (props: IHomeScreenProps) => {
           }
         });
     });
-  }, [dateOptions, rest]);
+  }, [dateOptions, rest]); // eslint-disable-line react-hooks/exhaustive-deps
+  // ^^^ Ignored dependency warning for selectString, since we do not want to re-fetch whenever selection changes
 
   useEffect(() => {
     if (loading) {

--- a/src/components/SettingsScreen.tsx
+++ b/src/components/SettingsScreen.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useContext } from "react";
 import Alert from "react-bootstrap/Alert";
 import Button from "react-bootstrap/Button";
 import ButtonGroup from "react-bootstrap/ButtonGroup";
@@ -13,6 +13,7 @@ import "../styles/settings.css";
 import { handleInputChange } from "../util/handleInputChange";
 import { Trans, useTranslation } from "react-i18next";
 import LanguagePicker from "./LanguagePicker";
+import RESTContext from "../services/rest/RESTContext";
 
 interface ISettingsScreenProps {
   dismiss: () => void;
@@ -25,6 +26,8 @@ const SettingsScreen = (props: ISettingsScreenProps) => {
   const [subjectsInput, setSubjectsInput] = useState(
     JSON.parse(window.localStorage.getItem("filter.subjects") ?? "[]")
   );
+
+  const rest = useContext(RESTContext);
 
   const { t } = useTranslation("SettingsScreen");
   const { t: tc } = useTranslation("common");
@@ -43,6 +46,8 @@ const SettingsScreen = (props: ISettingsScreenProps) => {
     window.localStorage.setItem("storage.ls.version", CURRENT_LOCALSTORAGE_SCHEMA_VERSION);
 
     window.localStorage.setItem("auth.token", authInput);
+    rest.setToken(authInput);
+
     window.localStorage.setItem("filter.class", classInput);
     window.localStorage.setItem(
       "filter.subjects",

--- a/src/services/rest/REST.ts
+++ b/src/services/rest/REST.ts
@@ -1,0 +1,61 @@
+import axios, { AxiosError, AxiosResponse } from "axios";
+import { makeApiErrorFromAxiosError } from "../../types/api/APIError";
+import APIResponse from "../../types/api/APIResponse";
+import APISubstitution from "../../types/api/APISubstitution";
+import { makeSubstitutionFromAPI, Substitution } from "../../types/Substitution";
+import DateFormatter from "../../util/DateFormatter";
+
+const DEFAULT_API_URL = "https://api.chuangsheep.com/vplan";
+
+type IRESTOptions = {
+  url: string;
+  token: string;
+};
+
+interface IREST {
+  settings: IRESTOptions;
+  setToken: (newValue: string) => void;
+  setUrl: (newValue: string) => void;
+  fetchPlan: (forDate: Date) => Promise<Substitution[]>;
+}
+
+const REST = class implements IREST {
+  settings: IRESTOptions;
+
+  constructor(token: string, url: string = DEFAULT_API_URL) {
+    this.settings = { url: url, token: token };
+  }
+
+  setToken = (newValue: string) => {
+    this.settings.token = newValue;
+    return this;
+  };
+
+  setUrl = (newValue: string) => {
+    this.settings.url = newValue;
+    return this;
+  };
+
+  fetchPlan = (forDate: Date) => {
+    return new Promise<Substitution[]>((resolve, reject) => {
+      const requestedDate = DateFormatter.apiDateString(forDate);
+      axios
+        .get(this.settings.url, {
+          params: {
+            date: requestedDate
+          },
+          headers: {
+            Authorization: "Bearer " + this.settings.token
+          }
+        })
+        .then((res: AxiosResponse<APIResponse>) => {
+          resolve(res.data.entries.map((entry: APISubstitution) => makeSubstitutionFromAPI(entry)));
+        })
+        .catch((err: AxiosError) => {
+          reject(makeApiErrorFromAxiosError(err));
+        });
+    });
+  };
+};
+
+export default REST;

--- a/src/services/rest/RESTContext.ts
+++ b/src/services/rest/RESTContext.ts
@@ -1,0 +1,4 @@
+import { createContext } from "react";
+import REST from "./REST";
+
+export default createContext(new REST(""));

--- a/src/util/dateUtil.ts
+++ b/src/util/dateUtil.ts
@@ -7,3 +7,18 @@ export const isWeekend = (date: Date) => {
     return true;
   }
 };
+
+export const getNextSchooldays = (amount: number) => {
+  let genOptions = [];
+  let itDate = new Date();
+
+  while (genOptions.length < amount) {
+    if (!isWeekend(itDate)) {
+      genOptions.push(new Date(itDate));
+    }
+
+    itDate.setDate(itDate.getDate() + 1);
+  }
+
+  return genOptions;
+};


### PR DESCRIPTION
With this PR, every time the app is loaded, it loads the data for all three date options (asynchronously) and displays the selected one ASAP, while keeping the other responses in state.

**Warning:** Currently, the data is fetched newly every time the component re-mounts - including when we return from settings, same issue as #29. Should probably be fixed before merging.

---

> hehe @ChuangSheep's API usage graph go brr

\- Me, before merging this PR

---

This PR closes #40.

<a href="https://gitpod.io/#https://github.com/kiriDevs/vplanweb/pull/46"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

