### PR TITLE
Add ignore-subjects-filter-switch; minor fixes

### DIFF
--- a/public/locales/de/HomeScreen.json
+++ b/public/locales/de/HomeScreen.json
@@ -24,5 +24,8 @@
   },
   "requestFeedback": {
     "success": "<0>{{amount}}</0> Einträge empfangen."
+  },
+  "ignoreSubjectsToggle": {
+    "description": "Fach-Filter ignorieren"
   }
 }

--- a/public/locales/en/HomeScreen.json
+++ b/public/locales/en/HomeScreen.json
@@ -24,5 +24,8 @@
   },
   "requestFeedback": {
     "success": "Successfully fetched <0>{{amount}}</0> entries."
+  },
+  "ignoreSubjectsToggle": {
+    "description": "Ignore subject filter"
   }
 }

--- a/src/components/DatePicker.tsx
+++ b/src/components/DatePicker.tsx
@@ -27,6 +27,7 @@ const DatePicker = (props: IDatePickerProps) => {
 
     setOptions(genOptions);
     select(genOptions[0]);
+    props.select(genOptions[0]);
   }, [props.maxDays]);
 
   return (

--- a/src/components/HomeScreen.tsx
+++ b/src/components/HomeScreen.tsx
@@ -136,7 +136,7 @@ const HomeScreen = (props: IHomeScreenProps) => {
               checked={filteringRelevant}
               onChange={handleCheckboxChange(handleFilterSwitch)}
             />
-            {filteringRelevant && (
+            {filteringRelevant && JSON.parse(window.localStorage.getItem("filter.subjects")!).length > 0 && (
               <Form.Switch
                 label={t("ignoreSubjectsToggle.description")}
                 checked={ignoringSubjects}

--- a/src/components/HomeScreen.tsx
+++ b/src/components/HomeScreen.tsx
@@ -25,6 +25,9 @@ const HomeScreen = (props: IHomeScreenProps) => {
   const [date, setDate] = useState(new Date());
   const [requestFeedback, setRequestFeedback] = useState({ type: "none" } as RequestFeedback);
   const [filteringRelevant, filterRelevant] = useState(JSON.parse(window.localStorage.getItem("filter") ?? "false"));
+  const [ignoringSubjects, ignoreSubjects] = useState(
+    JSON.parse(window.localStorage.getItem("filter.ignoreSubjects")!)
+  );
 
   const { t } = useTranslation("HomeScreen");
   const { t: tc } = useTranslation("common");
@@ -70,8 +73,17 @@ const HomeScreen = (props: IHomeScreenProps) => {
   };
 
   const handleFilterSwitch = (newValue: boolean) => {
+    if (newValue === false) {
+      ignoreSubjects(false);
+    }
+
     filterRelevant(newValue);
     window.localStorage.setItem("filter", JSON.stringify(newValue));
+  };
+
+  const handleIgnoreSubjectsSwitch = (newValue: boolean) => {
+    ignoreSubjects(newValue);
+    window.localStorage.setItem("filter.ignoreSubjects", JSON.stringify(newValue));
   };
 
   return (
@@ -124,6 +136,13 @@ const HomeScreen = (props: IHomeScreenProps) => {
               checked={filteringRelevant}
               onChange={handleCheckboxChange(handleFilterSwitch)}
             />
+            {filteringRelevant && (
+              <Form.Switch
+                label={t("ignoreSubjectsToggle.description")}
+                checked={ignoringSubjects}
+                onChange={handleCheckboxChange(handleIgnoreSubjectsSwitch)}
+              />
+            )}
           </Form>
 
           <RequestFeedbackAlert
@@ -135,7 +154,11 @@ const HomeScreen = (props: IHomeScreenProps) => {
         </ListGroup.Item>
 
         <ListGroup.Item>
-          <SubstitutionTable substitutions={renderedSubstitutions} relevantOnly={filteringRelevant} />
+          <SubstitutionTable
+            substitutions={renderedSubstitutions}
+            relevantOnly={filteringRelevant}
+            ignoreSubjects={ignoringSubjects}
+          />
         </ListGroup.Item>
 
         <ListGroup.Item>

--- a/src/components/RequestFeedbackAlert.tsx
+++ b/src/components/RequestFeedbackAlert.tsx
@@ -8,11 +8,11 @@ interface IRequestFeedbackAlertProps {
 }
 
 const RequestFeedbackAlert = (props: IRequestFeedbackAlertProps) => {
+  const { t } = useTranslation("HomeScreen");
+
   if (props.feedback.type === "none") {
     return <></>;
   }
-
-  const { t } = useTranslation("HomeScreen");
 
   return (
     <>

--- a/src/components/RequestFeedbackAlert.tsx
+++ b/src/components/RequestFeedbackAlert.tsx
@@ -24,7 +24,7 @@ const RequestFeedbackAlert = (props: IRequestFeedbackAlertProps) => {
       >
         {props.feedback.type === "success" ? (
           <Trans ns="HomeScreen" i18nKey="requestFeedback.success" values={{ amount: props.feedback.entryCount }}>
-            <strong>{props.feedback.entryCount}</strong>
+            <strong>amount</strong>
           </Trans>
         ) : (
           <>

--- a/src/components/SubstitutionTable.tsx
+++ b/src/components/SubstitutionTable.tsx
@@ -32,7 +32,7 @@ const SubstitutionTable = (props: ISubstitutionTableProps) => {
         return props.relevantOnly ? false : "normal";
       case "partial":
         if (!props.relevantOnly) {
-          return "partial";
+          return filterSubjects.length > 0 ? "partial" : "full";
         } else {
           return props.ignoreSubjects && "normal";
         }

--- a/src/components/SubstitutionTableRow.tsx
+++ b/src/components/SubstitutionTableRow.tsx
@@ -2,19 +2,34 @@ import { Substitution } from "../types/Substitution";
 
 interface ISubstitutionTableRowProps {
   substitution: Substitution;
-  highlighted: boolean;
+  style: "full" | "partial" | "normal" | false;
 }
 
-const SubstitutionTableRow = (props: ISubstitutionTableRowProps) => (
-  <tr className={props.highlighted ? "alert-primary text-black" : ""}>
-    <td>{props.substitution.period}</td>
-    <td>{props.substitution.substitute}</td>
-    <td>{props.substitution.subject}</td>
-    <td>{props.substitution.absent}</td>
-    <td>{props.substitution.class}</td>
-    <td>{props.substitution.room}</td>
-    <td>{props.substitution.note}</td>
-  </tr>
-);
+const SubstitutionTableRow = (props: ISubstitutionTableRowProps) => {
+  const classes = [] as string[];
+  if (props.style !== "normal") {
+    classes.push("text-black");
+    switch (props.style) {
+      case "partial":
+        classes.push("alert-dark");
+        break;
+      case "full":
+        classes.push("alert-primary");
+        break;
+    }
+  }
+
+  return (
+    <tr className={classes.join(" ")}>
+      <td>{props.substitution.period}</td>
+      <td>{props.substitution.substitute}</td>
+      <td>{props.substitution.subject}</td>
+      <td>{props.substitution.absent}</td>
+      <td>{props.substitution.class}</td>
+      <td>{props.substitution.room}</td>
+      <td>{props.substitution.note}</td>
+    </tr>
+  );
+};
 
 export default SubstitutionTableRow;

--- a/src/util/StorageManager.ts
+++ b/src/util/StorageManager.ts
@@ -6,7 +6,7 @@ interface IStorageManager {
   migrate: (from: string) => boolean;
 }
 
-export const CURRENT_LOCALSTORAGE_SCHEMA_VERSION = "1.3";
+export const CURRENT_LOCALSTORAGE_SCHEMA_VERSION = "1.4";
 
 export const shared: IStorageManager = {
   startup: () => {
@@ -36,6 +36,7 @@ export const shared: IStorageManager = {
     window.localStorage.setItem("filter.class", "");
     window.localStorage.setItem("filter.subjects", JSON.stringify([]));
     window.localStorage.setItem("filter", JSON.stringify(false));
+    window.localStorage.setItem("filter.ignoreSubjects", JSON.stringify(false));
     window.localStorage.setItem("lang", "en");
     window.localStorage.setItem("storage.ls.version", CURRENT_LOCALSTORAGE_SCHEMA_VERSION);
   },

--- a/src/util/StorageMigrators.ts
+++ b/src/util/StorageMigrators.ts
@@ -15,4 +15,8 @@ migrators.set("1.2", () => {
   window.localStorage.setItem("lang", "en");
 });
 
+migrators.set("1.3", () => {
+  window.localStorage.setItem("filter.ignoreSubjects", JSON.stringify(false));
+});
+
 export default migrators;


### PR DESCRIPTION
- fix: Internally select first genOption - Closes #45
- storage: Add filter.ignoreSubjects field
- feat: Allow ignoring classes in relevancy filtering - Closes #49
- fix: Fix error because of conditional hook usage
- i18n: Localize ignoreSubjectsToggle.description
- fix: Make react-i18next not complain about interpolation
- fix: Highlight partial matches as full if no subjects are specified


<a href="https://gitpod.io/#https://github.com/kiriDevs/vplanweb/pull/61"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

