### PR TITLE
Add Mobile UI for smaller screens

### DIFF
--- a/public/locales/de/HomeScreen.json
+++ b/public/locales/de/HomeScreen.json
@@ -33,6 +33,10 @@
       "eva": "Heute eigenverantwortliches Arbeiten (<0>EVA</0>)!",
       "nosub": "Findet heute nicht statt!",
       "sub": "Heute bei {{substitute}} statt bei {{absent}}!"
+    },
+    "invalidEntriesHint": {
+      "nInvalidEntries": "+ {{n}} fehlerhafte Einträge",
+      "tapForMore": "Tippen, um Quelldaten anzuzeigen"
     }
   }
 }

--- a/public/locales/de/HomeScreen.json
+++ b/public/locales/de/HomeScreen.json
@@ -32,7 +32,7 @@
     "subTexts": {
       "eva": "Heute eigenverantwortliches Arbeiten (<0>EVA</0>)!",
       "nosub": "Findet heute nicht statt!",
-      "sub": "Heute bei {{substitute}} statt bei {{absent}}!"
+      "sub": "Heute bei <0>{{substitute}}</0> statt bei <1>{{absent}}</1>!"
     },
     "invalidEntriesHint": {
       "nInvalidEntries": "+ {{n}} fehlerhafte Einträge",

--- a/public/locales/de/HomeScreen.json
+++ b/public/locales/de/HomeScreen.json
@@ -27,5 +27,12 @@
   },
   "ignoreSubjectsToggle": {
     "description": "Fach-Filter ignorieren"
+  },
+  "mobileui": {
+    "subTexts": {
+      "eva": "Heute eigenverantwortliches Arbeiten (<0>EVA</0>)!",
+      "nosub": "Findet heute nicht statt!",
+      "sub": "Heute bei {{substitute}} statt bei {{absent}}!"
+    }
   }
 }

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -7,5 +7,6 @@
     "cancel": "Abbrechen"
   },
   "loading": "Laden...",
-  "nth-period": "{{n}}. Stunde"
+  "nth-period": "{{n}}. Stunde",
+  "n-entries": "{{n}} Einträge"
 }

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -6,5 +6,6 @@
     "save": "Speichern",
     "cancel": "Abbrechen"
   },
-  "loading": "Laden..."
+  "loading": "Laden...",
+  "nth-period": "{{n}}. Stunde"
 }

--- a/public/locales/en/HomeScreen.json
+++ b/public/locales/en/HomeScreen.json
@@ -32,7 +32,7 @@
     "subTexts": {
       "eva": "Working independently today (<0>EVA</0>)!",
       "nosub": "Does not take place today!",
-      "sub": "Today with {{substitute}} instead of {{absent}}!"
+      "sub": "Today with <0>{{substitute}}</0> instead of <1>{{absent}}</1>!"
     },
     "invalidEntriesHint": {
       "nInvalidEntries": "+ {{n}} invalid entries",

--- a/public/locales/en/HomeScreen.json
+++ b/public/locales/en/HomeScreen.json
@@ -27,5 +27,12 @@
   },
   "ignoreSubjectsToggle": {
     "description": "Ignore subject filter"
+  },
+  "mobileui": {
+    "subTexts": {
+      "eva": "Working independently today (<0>EVA</0>)!",
+      "nosub": "Does not take place today!",
+      "sub": "Today with {{substitute}} instead of {{absent}}!"
+    }
   }
 }

--- a/public/locales/en/HomeScreen.json
+++ b/public/locales/en/HomeScreen.json
@@ -33,6 +33,10 @@
       "eva": "Working independently today (<0>EVA</0>)!",
       "nosub": "Does not take place today!",
       "sub": "Today with {{substitute}} instead of {{absent}}!"
+    },
+    "invalidEntriesHint": {
+      "nInvalidEntries": "+ {{n}} invalid entries",
+      "tapForMore": "Tap to show raw data"
     }
   }
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -6,5 +6,6 @@
     "save": "Save",
     "cancel": "Cancel"
   },
-  "loading": "Loading..."
+  "loading": "Loading...",
+  "nth-period": "{{n}}. period"
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -7,5 +7,9 @@
     "cancel": "Cancel"
   },
   "loading": "Loading...",
-  "nth-period": "{{n}}. period"
+  "nth-period": "{{n}}. period",
+  "entries": {
+    "one": "entry",
+    "more": "{{n}} entries"
+  }
 }

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -4,8 +4,6 @@ import HomeScreen from "./HomeScreen";
 import SettingsScreen from "./SettingsScreen";
 import { shared as StorageManager } from "../util/StorageManager";
 
-import { Substitution } from "../types/Substitution";
-
 import "../styles/general.css";
 
 const App = () => {

--- a/src/components/HomeScreen.tsx
+++ b/src/components/HomeScreen.tsx
@@ -13,6 +13,9 @@ import { Trans, useTranslation } from "react-i18next";
 import DatePicker from "./DatePicker";
 
 import { Button, Form, ListGroup, Spinner, Stack } from "react-bootstrap";
+import { FilterContextProvider } from "../context/FilterContext";
+import SubstitutionList from "./SubstitutionList";
+import { IRelevancyFilterOptions } from "../util/relevancyFilter";
 
 interface IHomeScreenProps {
   showSettings: () => void;
@@ -86,10 +89,22 @@ const HomeScreen = (props: IHomeScreenProps) => {
     window.localStorage.setItem("filter.ignoreSubjects", JSON.stringify(newValue));
   };
 
+  const [filterClass] = useState(window.localStorage.getItem("filter.class")!);
+  const [filterSubjects] = useState(JSON.parse(window.localStorage.getItem("filter.subjects")!));
+  const filterOptions = {
+    class: filterClass,
+    subjects: filterSubjects,
+    filterMode: {
+      filtering: filteringRelevant,
+      ignoringSubjects: ignoringSubjects
+    }
+  } as IRelevancyFilterOptions;
+
+  const useMobileUi = window.innerWidth <= 500;
+
   return (
     <>
       <h1 className="vplan-heading">VPlan</h1>
-
       <ListGroup>
         <ListGroup.Item>
           <Form
@@ -154,11 +169,17 @@ const HomeScreen = (props: IHomeScreenProps) => {
         </ListGroup.Item>
 
         <ListGroup.Item>
-          <SubstitutionTable
-            substitutions={renderedSubstitutions}
-            relevantOnly={filteringRelevant}
-            ignoreSubjects={ignoringSubjects}
-          />
+          <FilterContextProvider value={filterOptions}>
+            {useMobileUi ? (
+              <SubstitutionList substitutions={renderedSubstitutions} />
+            ) : (
+              <SubstitutionTable
+                substitutions={renderedSubstitutions}
+                relevantOnly={filteringRelevant}
+                ignoreSubjects={ignoringSubjects}
+              />
+            )}
+          </FilterContextProvider>
         </ListGroup.Item>
 
         <ListGroup.Item>

--- a/src/components/HomeScreen.tsx
+++ b/src/components/HomeScreen.tsx
@@ -32,6 +32,19 @@ const HomeScreen = (props: IHomeScreenProps) => {
     JSON.parse(window.localStorage.getItem("filter.ignoreSubjects")!)
   );
 
+  const [usingMobileUi, useMobileUi] = useState(window.innerWidth <= 500);
+  useEffect(() => {
+    const resizeListener = () => {
+      useMobileUi(window.innerWidth <= 500);
+    };
+
+    window.addEventListener("resize", resizeListener);
+
+    return () => {
+      window.removeEventListener("resize", resizeListener);
+    };
+  }, []);
+
   const { t } = useTranslation("HomeScreen");
   const { t: tc } = useTranslation("common");
 
@@ -99,8 +112,6 @@ const HomeScreen = (props: IHomeScreenProps) => {
       ignoringSubjects: ignoringSubjects
     }
   } as IRelevancyFilterOptions;
-
-  const useMobileUi = window.innerWidth <= 500;
 
   return (
     <>
@@ -170,7 +181,7 @@ const HomeScreen = (props: IHomeScreenProps) => {
 
         <ListGroup.Item>
           <FilterContextProvider value={filterOptions}>
-            {useMobileUi ? (
+            {usingMobileUi ? (
               <SubstitutionList substitutions={renderedSubstitutions} />
             ) : (
               <SubstitutionTable

--- a/src/components/SubstitutionList.tsx
+++ b/src/components/SubstitutionList.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useState } from "react";
+import { Accordion } from "react-bootstrap";
+import { Substitution } from "../types/Substitution";
+
+import SubstitutionListGroup from "./SubstitutionListGroup";
+
+interface ISubstitutionListProps {
+  substitutions: Substitution[];
+}
+
+const SubstitutionList = (props: ISubstitutionListProps) => {
+  const [periods, setPeriods] = useState([] as number[]);
+
+  useEffect(() => {
+    const _periods = [] as number[];
+    props.substitutions.forEach((substitution: Substitution) => {
+      if (!_periods.includes(substitution.period)) {
+        _periods.push(substitution.period);
+      }
+    });
+    setPeriods(_periods);
+  }, [props.substitutions]);
+
+  return (
+    <Accordion
+      defaultActiveKey={periods.map((period) => `#-mobile-accordion-section${period.toString()}}`)}
+      alwaysOpen
+      flush
+    >
+      {periods.map((period) => (
+        <SubstitutionListGroup
+          period={period}
+          substitutions={props.substitutions.filter((substitution: Substitution) => substitution.period === period)}
+        />
+      ))}
+    </Accordion>
+  );
+};
+
+export default SubstitutionList;

--- a/src/components/SubstitutionList.tsx
+++ b/src/components/SubstitutionList.tsx
@@ -21,7 +21,7 @@ const SubstitutionList = (props: ISubstitutionListProps) => {
     setPeriods(_periods);
   }, [props.substitutions]);
 
-  return (
+  return props.substitutions.length !== 0 ? (
     <Accordion
       defaultActiveKey={periods.map((period) => `#-mobile-accordion-section${period.toString()}}`)}
       alwaysOpen
@@ -29,11 +29,14 @@ const SubstitutionList = (props: ISubstitutionListProps) => {
     >
       {periods.map((period) => (
         <SubstitutionListGroup
+          key={`#-mobile-accordion-section${period.toString()}`}
           period={period}
           substitutions={props.substitutions.filter((substitution: Substitution) => substitution.period === period)}
         />
       ))}
     </Accordion>
+  ) : (
+    <></>
   );
 };
 

--- a/src/components/SubstitutionListCell.tsx
+++ b/src/components/SubstitutionListCell.tsx
@@ -1,0 +1,61 @@
+import { ListGroupItem } from "react-bootstrap";
+import { FilterContextConsumer } from "../context/FilterContext";
+import { Substitution } from "../types/Substitution";
+import getRenderStyle from "../util/relevancyFilter";
+
+interface ISubstitutionListCellProps {
+  substitution: Substitution;
+}
+
+const renderSubstitute = (substitution: Substitution) => {
+  switch (substitution.substitute) {
+    case "EVA":
+      return (
+        <>
+          Heute Eigenverantwortliches Arbeiten (<strong>EVA</strong>)
+        </>
+      );
+    case "---":
+      return "Findet heute nicht statt!";
+    default:
+      return "Heute bei " + substitution.substitute + " statt bei " + substitution.absent;
+  }
+};
+
+const SubstitutionListCell = (props: ISubstitutionListCellProps) => (
+  <FilterContextConsumer>
+    {(filterOptions) => {
+      const renderStyle = getRenderStyle(props.substitution, filterOptions);
+      let styleVariant = "";
+      switch (renderStyle) {
+        case "partial":
+          styleVariant = "secondary";
+          break;
+        case "full":
+          styleVariant = "primary";
+          break;
+      }
+
+      return (
+        <ListGroupItem variant={styleVariant}>
+          <>
+            <strong>
+              {props.substitution.class}: {props.substitution.subject} ({props.substitution.room})
+            </strong>
+            <br />
+            {renderSubstitute(props.substitution)}
+
+            {props.substitution.note !== "" && (
+              <>
+                <br />
+                {props.substitution.note}
+              </>
+            )}
+          </>
+        </ListGroupItem>
+      );
+    }}
+  </FilterContextConsumer>
+);
+
+export default SubstitutionListCell;

--- a/src/components/SubstitutionListCell.tsx
+++ b/src/components/SubstitutionListCell.tsx
@@ -29,7 +29,6 @@ const renderSubstitute = (substitution: Substitution, t: TFunction) => {
           <strong>{substitution.absent}</strong>
         </Trans>
       );
-    //t("subTexts.sub", { replace: { substitute: substitution.substitute, absent: substitution.absent } });
   }
 };
 

--- a/src/components/SubstitutionListCell.tsx
+++ b/src/components/SubstitutionListCell.tsx
@@ -19,7 +19,17 @@ const renderSubstitute = (substitution: Substitution, t: TFunction) => {
     case "---":
       return t("subTexts.nosub");
     default:
-      return t("subTexts.sub", { replace: { substitute: substitution.substitute, absent: substitution.absent } });
+      return (
+        <Trans
+          t={t}
+          i18nKey="subTexts.sub"
+          values={{ substitute: substitution.substitute, absent: substitution.absent }}
+        >
+          <strong>{substitution.substitute}</strong>
+          <strong>{substitution.absent}</strong>
+        </Trans>
+      );
+    //t("subTexts.sub", { replace: { substitute: substitution.substitute, absent: substitution.absent } });
   }
 };
 

--- a/src/components/SubstitutionListCell.tsx
+++ b/src/components/SubstitutionListCell.tsx
@@ -1,4 +1,5 @@
 import { ListGroupItem } from "react-bootstrap";
+import { TFunction, Trans, useTranslation } from "react-i18next";
 import { FilterContextConsumer } from "../context/FilterContext";
 import { Substitution } from "../types/Substitution";
 import getRenderStyle from "../util/relevancyFilter";
@@ -7,55 +8,59 @@ interface ISubstitutionListCellProps {
   substitution: Substitution;
 }
 
-const renderSubstitute = (substitution: Substitution) => {
+const renderSubstitute = (substitution: Substitution, t: TFunction) => {
   switch (substitution.substitute) {
     case "EVA":
       return (
-        <>
-          Heute Eigenverantwortliches Arbeiten (<strong>EVA</strong>)
-        </>
+        <Trans t={t} i18nKey="subTexts.eva">
+          <strong>EVA</strong>
+        </Trans>
       );
     case "---":
-      return "Findet heute nicht statt!";
+      return t("subTexts.nosub");
     default:
-      return "Heute bei " + substitution.substitute + " statt bei " + substitution.absent;
+      return t("subTexts.sub", { replace: { substitute: substitution.substitute, absent: substitution.absent } });
   }
 };
 
-const SubstitutionListCell = (props: ISubstitutionListCellProps) => (
-  <FilterContextConsumer>
-    {(filterOptions) => {
-      const renderStyle = getRenderStyle(props.substitution, filterOptions);
-      let styleVariant = "";
-      switch (renderStyle) {
-        case "partial":
-          styleVariant = "secondary";
-          break;
-        case "full":
-          styleVariant = "primary";
-          break;
-      }
+const SubstitutionListCell = (props: ISubstitutionListCellProps) => {
+  const { t } = useTranslation("HomeScreen", { keyPrefix: "mobileui" });
 
-      return (
-        <ListGroupItem variant={styleVariant}>
-          <>
-            <strong>
-              {props.substitution.class}: {props.substitution.subject} ({props.substitution.room})
-            </strong>
-            <br />
-            {renderSubstitute(props.substitution)}
+  return (
+    <FilterContextConsumer>
+      {(filterOptions) => {
+        const renderStyle = getRenderStyle(props.substitution, filterOptions);
+        let styleVariant = "";
+        switch (renderStyle) {
+          case "partial":
+            styleVariant = "secondary";
+            break;
+          case "full":
+            styleVariant = "primary";
+            break;
+        }
 
-            {props.substitution.note !== "" && (
-              <>
-                <br />
-                {props.substitution.note}
-              </>
-            )}
-          </>
-        </ListGroupItem>
-      );
-    }}
-  </FilterContextConsumer>
-);
+        return (
+          <ListGroupItem variant={styleVariant}>
+            <>
+              <strong>
+                {props.substitution.class}: {props.substitution.subject} ({props.substitution.room})
+              </strong>
+              <br />
+              {renderSubstitute(props.substitution, t)}
+
+              {props.substitution.note !== "" && (
+                <>
+                  <br />
+                  {props.substitution.note}
+                </>
+              )}
+            </>
+          </ListGroupItem>
+        );
+      }}
+    </FilterContextConsumer>
+  );
+};
 
 export default SubstitutionListCell;

--- a/src/components/SubstitutionListGroup.tsx
+++ b/src/components/SubstitutionListGroup.tsx
@@ -49,7 +49,10 @@ const SubstitutionListGroup = (props: ISubstitutionListGroupProps) => {
       </AccordionHeader>
       <AccordionBody className="p-0">
         {props.substitutions.map((substitution: Substitution) => (
-          <SubstitutionListCell substitution={substitution} />
+          <SubstitutionListCell
+            substitution={substitution}
+            key={`#-mobile-accordion-section${props.period.toString()}-${substitution.class}|${substitution.subject}`}
+          />
         ))}
       </AccordionBody>
     </AccordionItem>

--- a/src/components/SubstitutionListGroup.tsx
+++ b/src/components/SubstitutionListGroup.tsx
@@ -5,8 +5,9 @@ import { Substitution } from "../types/Substitution";
 import SubstitutionListCell from "./SubstitutionListCell";
 import { Badge, Stack } from "react-bootstrap";
 import getRenderStyle from "../util/relevancyFilter";
-import { useContext, useEffect, useState } from "react";
+import { useContext, useEffect, useState, useTransition } from "react";
 import FilterContext from "../context/FilterContext";
+import { useTranslation } from "react-i18next";
 
 interface ISubstitutionListGroupProps {
   period: number;
@@ -18,6 +19,8 @@ const SubstitutionListGroup = (props: ISubstitutionListGroupProps) => {
 
   const [partialMatchCount, setPartialMatchCount] = useState(0);
   const [fullMatchCount, setFullMatchCount] = useState(0);
+
+  const { t: tc } = useTranslation("common");
 
   useEffect(() => {
     const fullMatches = props.substitutions.filter((sub) => getRenderStyle(sub, filterOptions) == "full");
@@ -31,7 +34,7 @@ const SubstitutionListGroup = (props: ISubstitutionListGroupProps) => {
     <AccordionItem eventKey={`#-mobile-accordion-section${props.period.toString()}`} className="show">
       <AccordionHeader>
         <Stack direction="horizontal" className="w-100">
-          <strong>{props.period}. Stunde</strong>
+          <strong>{tc("nth-period", { replace: { n: props.period } })}</strong>
           <Stack direction="horizontal" className="ms-auto" gap={1} style={{ paddingRight: "0.6em" }}>
             {partialMatchCount > 0 && (
               <Badge bg="secondary" pill>

--- a/src/components/SubstitutionListGroup.tsx
+++ b/src/components/SubstitutionListGroup.tsx
@@ -44,6 +44,7 @@ const SubstitutionListGroup = (props: ISubstitutionListGroupProps) => {
   const [validEntries, setValidEntries] = useState([] as Substitution[]);
   const [invalidEntries, setInvalidEntries] = useState([] as Substitution[]);
 
+  const { t } = useTranslation("HomeScreen", { keyPrefix: "mobileui" });
   const { t: tc } = useTranslation("common");
 
   useEffect(() => {
@@ -99,9 +100,9 @@ const SubstitutionListGroup = (props: ISubstitutionListGroupProps) => {
               alert(JSON.stringify(invalidEntries, undefined, 2));
             }}
           >
-            <strong>+ {invalidEntries.length} invalid entries</strong>
+            <strong>{t("invalidEntriesHint.nInvalidEntries", { replace: { n: invalidEntries.length } })}</strong>
             <br />
-            <span>Tap to show raw data</span>
+            <span>{t("invalidEntriesHint.tapForMore")}</span>
           </ListGroupItem>
         )}
       </AccordionBody>

--- a/src/components/SubstitutionListGroup.tsx
+++ b/src/components/SubstitutionListGroup.tsx
@@ -1,0 +1,25 @@
+import AccordionHeader from "react-bootstrap/esm/AccordionHeader";
+import AccordionBody from "react-bootstrap/esm/AccordionBody";
+import AccordionItem from "react-bootstrap/esm/AccordionItem";
+import { Substitution } from "../types/Substitution";
+import SubstitutionListCell from "./SubstitutionListCell";
+
+interface ISubstitutionListGroupProps {
+  period: number;
+  substitutions: Substitution[];
+}
+
+const SubstitutionListGroup = (props: ISubstitutionListGroupProps) => (
+  <AccordionItem eventKey={`#-mobile-accordion-section${props.period.toString()}`} className="show">
+    <AccordionHeader>
+      <strong>{props.period}. Stunde</strong>
+    </AccordionHeader>
+    <AccordionBody className="p-0">
+      {props.substitutions.map((substitution: Substitution) => (
+        <SubstitutionListCell substitution={substitution} />
+      ))}
+    </AccordionBody>
+  </AccordionItem>
+);
+
+export default SubstitutionListGroup;

--- a/src/components/SubstitutionListGroup.tsx
+++ b/src/components/SubstitutionListGroup.tsx
@@ -3,23 +3,57 @@ import AccordionBody from "react-bootstrap/esm/AccordionBody";
 import AccordionItem from "react-bootstrap/esm/AccordionItem";
 import { Substitution } from "../types/Substitution";
 import SubstitutionListCell from "./SubstitutionListCell";
+import { Badge, Stack } from "react-bootstrap";
+import getRenderStyle from "../util/relevancyFilter";
+import { useContext, useEffect, useState } from "react";
+import FilterContext from "../context/FilterContext";
 
 interface ISubstitutionListGroupProps {
   period: number;
   substitutions: Substitution[];
 }
 
-const SubstitutionListGroup = (props: ISubstitutionListGroupProps) => (
-  <AccordionItem eventKey={`#-mobile-accordion-section${props.period.toString()}`} className="show">
-    <AccordionHeader>
-      <strong>{props.period}. Stunde</strong>
-    </AccordionHeader>
-    <AccordionBody className="p-0">
-      {props.substitutions.map((substitution: Substitution) => (
-        <SubstitutionListCell substitution={substitution} />
-      ))}
-    </AccordionBody>
-  </AccordionItem>
-);
+const SubstitutionListGroup = (props: ISubstitutionListGroupProps) => {
+  const filterOptions = useContext(FilterContext);
+
+  const [partialMatchCount, setPartialMatchCount] = useState(0);
+  const [fullMatchCount, setFullMatchCount] = useState(0);
+
+  useEffect(() => {
+    const fullMatches = props.substitutions.filter((sub) => getRenderStyle(sub, filterOptions) == "full");
+    setFullMatchCount(fullMatches.length);
+
+    const partialMatches = props.substitutions.filter((sub) => getRenderStyle(sub, filterOptions) == "partial");
+    setPartialMatchCount(partialMatches.length);
+  }, [props.substitutions]);
+
+  return (
+    <AccordionItem eventKey={`#-mobile-accordion-section${props.period.toString()}`} className="show">
+      <AccordionHeader>
+        <Stack direction="horizontal" className="w-100">
+          <strong>{props.period}. Stunde</strong>
+          <Stack direction="horizontal" className="ms-auto" gap={1} style={{ paddingRight: "0.6em" }}>
+            {partialMatchCount > 0 && (
+              <Badge bg="secondary" pill>
+                {partialMatchCount}
+              </Badge>
+            )}
+
+            {fullMatchCount > 0 && (
+              <Badge bg="primary" pill>
+                {fullMatchCount}
+              </Badge>
+            )}
+          </Stack>
+        </Stack>
+      </AccordionHeader>
+      <AccordionBody className="p-0">
+        {props.substitutions.map((substitution: Substitution) => (
+          <SubstitutionListCell substitution={substitution} />
+        ))}
+      </AccordionBody>
+    </AccordionItem>
+  );
+};
 
 export default SubstitutionListGroup;

--- a/src/components/SubstitutionListGroup.tsx
+++ b/src/components/SubstitutionListGroup.tsx
@@ -65,7 +65,13 @@ const SubstitutionListGroup = (props: ISubstitutionListGroupProps) => {
         <Stack direction="horizontal" className="w-100">
           <Stack>
             <strong>{tc("nth-period", { replace: { n: props.period } })}</strong>
-            <span className="text-secondary">{props.substitutions.length} entries</span>
+            {props.substitutions.length === 1 ? (
+              <span className="text-secondary">1 {tc("entries.one")}</span>
+            ) : (
+              <span className="text-secondary">
+                {tc("entries.more", { replace: { n: props.substitutions.length } })}
+              </span>
+            )}
           </Stack>
           <Stack direction="horizontal" className="ms-auto" gap={1} style={{ paddingRight: "0.6em" }}>
             {partialMatchCount > 0 && (

--- a/src/components/SubstitutionListGroup.tsx
+++ b/src/components/SubstitutionListGroup.tsx
@@ -63,7 +63,10 @@ const SubstitutionListGroup = (props: ISubstitutionListGroupProps) => {
     <AccordionItem eventKey={`#-mobile-accordion-section${props.period.toString()}`} className="show">
       <AccordionHeader>
         <Stack direction="horizontal" className="w-100">
-          <strong>{tc("nth-period", { replace: { n: props.period } })}</strong>
+          <Stack>
+            <strong>{tc("nth-period", { replace: { n: props.period } })}</strong>
+            <span className="text-secondary">{props.substitutions.length} entries</span>
+          </Stack>
           <Stack direction="horizontal" className="ms-auto" gap={1} style={{ paddingRight: "0.6em" }}>
             {partialMatchCount > 0 && (
               <Badge bg="secondary" pill>

--- a/src/components/SubstitutionTable.tsx
+++ b/src/components/SubstitutionTable.tsx
@@ -3,7 +3,7 @@ import Table from "react-bootstrap/Table";
 import { useTranslation } from "react-i18next";
 import { Substitution } from "../types/Substitution";
 import SubstitutionTableRow from "./SubstitutionTableRow";
-import getRenderStyle, { IRelevancyFilterOptions } from "../util/relevancyFilter";
+import getRenderStyle from "../util/relevancyFilter";
 
 interface ISubstitutionTableProps {
   substitutions: Substitution[];

--- a/src/context/FilterContext.ts
+++ b/src/context/FilterContext.ts
@@ -1,0 +1,17 @@
+import { createContext } from "react";
+import { IRelevancyFilterOptions } from "../util/relevancyFilter";
+
+const defaultValue = {
+  class: "",
+  subjects: [],
+  filterMode: {
+    filtering: false,
+    ignoringSubjects: false
+  }
+} as IRelevancyFilterOptions;
+
+const FilterContext = createContext(defaultValue);
+
+export default FilterContext;
+export const FilterContextProvider = FilterContext.Provider;
+export const FilterContextConsumer = FilterContext.Consumer;

--- a/src/util/relevancyFilter.ts
+++ b/src/util/relevancyFilter.ts
@@ -25,7 +25,6 @@ const getRenderStyle = (substitution: Substitution, options: IRelevancyFilterOpt
       return options.filterMode.filtering ? false : "normal";
     case "partial":
       const ignoreSubjects = options.filterMode.ignoringSubjects || options.subjects.length === 0;
-      console.log(options.filterMode.ignoringSubjects, options.subjects.length, ignoreSubjects);
       if (!options.filterMode.filtering) {
         if (!ignoreSubjects) {
           return "partial";


### PR DESCRIPTION
Adds an alternative UI for smaller screens. When the site is loaded with a screen width smaller than or equal to `500`px, the `<SubstitutionTable>` will be replaced by a `<SubstitutionList>`. It is divided into multiple `<SubstitutionListGroup>`s, named by their respective periods. Groups will only be created for periods that actually have entries on the fetched plan. These groups are expandable (and collapsible) by the user to reveal (or hide) `<SubstitutionListCell>`s. These will display one plan entry each. 

![image](https://user-images.githubusercontent.com/56218513/177131292-70aaa20c-bab2-4b06-a366-9fea58a1cf66.png)


<a href="https://gitpod.io/#https://github.com/kiriDevs/vplanweb/pull/66"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

---

### Remaining ToDos:
- [x] Badges showing the amount of relevant entries for each period
- [x] i18n of the new strings

---
This PR closes #55 (which is funny because `#66` closes `#55`)

