### PR TITLE
Fix filtering for mobileui; Fix keys for `SubstitutionListEntry`s

### DIFF
--- a/src/components/SubstitutionList.tsx
+++ b/src/components/SubstitutionList.tsx
@@ -1,8 +1,10 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useContext } from "react";
 import { Accordion } from "react-bootstrap";
 import { Substitution } from "../types/Substitution";
 
 import SubstitutionListGroup from "./SubstitutionListGroup";
+import getRenderStyle from "../util/relevancyFilter";
+import FilterContext from "../context/FilterContext";
 
 interface ISubstitutionListProps {
   substitutions: Substitution[];
@@ -10,18 +12,27 @@ interface ISubstitutionListProps {
 
 const SubstitutionList = (props: ISubstitutionListProps) => {
   const [periods, setPeriods] = useState([] as number[]);
+  const [relevantEntries, setRelevantEntries] = useState([] as Substitution[]);
+
+  const filterOptions = useContext(FilterContext);
 
   useEffect(() => {
+    const _relevantEntries = [] as Substitution[];
     const _periods = [] as number[];
     props.substitutions.forEach((substitution: Substitution) => {
-      if (!_periods.includes(substitution.period)) {
-        _periods.push(substitution.period);
+      if (getRenderStyle(substitution, filterOptions)) {
+        _relevantEntries.push(substitution);
+        if (!_periods.includes(substitution.period)) {
+          _periods.push(substitution.period);
+        }
       }
     });
-    setPeriods(_periods);
-  }, [props.substitutions]);
 
-  return props.substitutions.length !== 0 ? (
+    setRelevantEntries(_relevantEntries);
+    setPeriods(_periods);
+  }, [props.substitutions, filterOptions]);
+
+  return relevantEntries.length !== 0 ? (
     <Accordion
       defaultActiveKey={periods.map((period) => `#-mobile-accordion-section${period.toString()}}`)}
       alwaysOpen
@@ -31,7 +42,7 @@ const SubstitutionList = (props: ISubstitutionListProps) => {
         <SubstitutionListGroup
           key={`#-mobile-accordion-section${period.toString()}`}
           period={period}
-          substitutions={props.substitutions.filter((substitution: Substitution) => substitution.period === period)}
+          substitutions={relevantEntries.filter((substitution: Substitution) => substitution.period === period)}
         />
       ))}
     </Accordion>

--- a/src/components/SubstitutionListGroup.tsx
+++ b/src/components/SubstitutionListGroup.tsx
@@ -98,7 +98,9 @@ const SubstitutionListGroup = (props: ISubstitutionListGroupProps) => {
         {validEntries.map((substitution: Substitution) => (
           <SubstitutionListCell
             substitution={substitution}
-            key={`#-mobile-accordion-section${props.period.toString()}-${substitution.class}|${substitution.subject}`}
+            key={`#-mobile-accordion-section${props.period.toString()}-${substitution.class}|${substitution.subject}|${
+              substitution.room
+            }`}
           />
         ))}
 


### PR DESCRIPTION
- fix: Implement filtering for SubstitutionList (mobileui)
- fix: Add room to SubstitutionListEntry key props

---
Closes #70


<a href="https://gitpod.io/#https://github.com/kiriDevs/vplanweb/pull/71"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

