### PR TITLE
dev(devc): Remove auto-closing-tag

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,6 @@
 
   "extensions": [
     "esbenp.prettier-vscode",
-    "formulahendry.auto-close-tag",
     "formulahendry.auto-rename-tag"
   ],
 


### PR DESCRIPTION
It's more annoying than helpful, because VSCode apparently has the functionality built-in already, meaning that you then have two closing tags and have to delete one again
