### PR TITLE
Minor Tweaks

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,6 @@
 
   "extensions": [
     "esbenp.prettier-vscode",
-    "formulahendry.auto-close-tag",
     "formulahendry.auto-rename-tag"
   ],
 

--- a/src/components/HomeScreen.tsx
+++ b/src/components/HomeScreen.tsx
@@ -55,7 +55,11 @@ const HomeScreen = (props: IHomeScreenProps) => {
   const selectString = DateFormatter.apiDateString(selection);
 
   useEffect(() => {
-    setDateOptions(getNextSchooldays(3));
+    const options = getNextSchooldays(3);
+    setDateOptions(options);
+
+    // Always select the first option (-> weekends)
+    select(options[0]);
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
- remove `auto-closing-tag` from the devcontainer, since VSCode has that functionality built in now
- fix substitution plan for next school day not showing up automatically on weekends (thanks @ChuangSheep for reporting)