### PR TITLE
fix: Update localstorage ignoreSubjects on autoOff

### DIFF
--- a/src/components/HomeScreen.tsx
+++ b/src/components/HomeScreen.tsx
@@ -115,7 +115,7 @@ const HomeScreen = (props: IHomeScreenProps) => {
 
   const handleFilterSwitch = (newValue: boolean) => {
     if (newValue === false) {
-      ignoreSubjects(false);
+      handleIgnoreSubjectsSwitch(false);
     }
 
     filterRelevant(newValue);


### PR DESCRIPTION
Until now, when filtering was turned off, ignoreSubjects was turned of in state, but not in localStorage. This led to unexpected behaviour for mobileUI badges (displaying all substitutions as full-relevant / blue).

- Fixes #76